### PR TITLE
bump osdctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ FROM builder as osdctl-builder
 # Add `osdctl` utility for common OSD commands
 # Replace "/latest" with "/tags/{tag}" to pin to a specific version (eg: "/tags/v0.4.0")
 # the URL_SLUG is for checking the releasenotes when a version updates
-ARG OSDCTL_VERSION="tags/v0.13.4"
+ARG OSDCTL_VERSION="tags/v0.13.7"
 ENV OSDCTL_URL_SLUG="openshift/osdctl"
 ENV OSDCTL_URL="https://api.github.com/repos/${OSDCTL_URL_SLUG}/releases/${OSDCTL_VERSION}"
 


### PR DESCRIPTION
bump osdctl to suggested as seen from
```
The current version (0.13.6) is different than the latest released version (v0.13.7).
It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Please confirm that you would like to continue with [y|n]
```